### PR TITLE
fix: delimiter that breaks due to stripe message and csv dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
 
     # writing to export.csv
     with open('export.csv', 'w', newline='', encoding='utf-8') as exportFile:
-        writer = csv.writer(exportFile)
+        writer = csv.writer(exportFile, delimiter=';')
 
         writer.writerow(csv_header())
         writer.writerows(everhypeCSV)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-csv
 stripe


### PR DESCRIPTION
I am not experienced in Python, but the CSV dependency failed to download and online I read that it's included in the main python installation by now? Anyhow it doesn't break after having removed it.

Also the configured Stripe name has a comma inside which collides with the default delimiter. I changed the delimiter to a semicolon.

Thanks for writing the quick script! It really helped us out :)